### PR TITLE
Revert rescript-react migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Reshowcase
 
+⚠️ this is a fork of [original tool](https://github.com/bloodyowl/reshowcase) with `rescript-react` migration reverted, `reason-react` is used instead ⚠️
+
 > A tool to create demos for your ReScript React components
 
 ![Screenshot](./example/example-2021.png)

--- a/README.md
+++ b/README.md
@@ -8,35 +8,32 @@
 open Reshowcase.Entry
 
 // Create a demo
-demo(({addCategory}) => {
-  addCategory("Title", ({addDemo}) => {
-    // Add an example
-    addDemo("normal", ({string}) =>
-      // Register "handles" from your JSX directly
-      <h1> {string("text", "hello")->React.string} </h1>
-    )
-    addDemo("font-size", ({string, int}) =>
-      <h1
-        style={ReactDOM.Style.make(
-          ~fontSize=// Handles can be strings, ints, floats and booleans
-
-          {
-            let size = int("font size", {min: 0, max: 100, initial: 30, step: 1})
-            `${size->Belt.Int.toString}px`
-          },
-          (),
-        )}>
-        {string("text", "hello")->React.string}
-      </h1>
-    )
-  })
+demo("Title", ({add}) => {
+  // Add an example
+  add("normal", ({string}) =>
+    // Register "handles" from your JSX directly
+    <h1> {string("text", "hello")->React.string} </h1>
+  )
+  add("font-size", ({string, int}) =>
+    <h1
+      style={ReactDOM.Style.make(
+        ~fontSize={
+          // Handles can be strings, ints, floats and booleans
+          let size = int("font size", {min: 0, max: 100, initial: 30, step: 1})
+          `${size->Belt.Int.toString}px`
+        },
+        (),
+      )}>
+      {string("text", "hello")->React.string}
+    </h1>
+  )
 })
 
-demo(({addCategory}) =>
-  addCategory("Button", ({addDemo}) =>
-    addDemo("normal", ({string, bool}) =>
-      <button disabled={bool("disabled", false)}> {string("text", "hello")->React.string} </button>
-    )
+demo("Button", ({add}) =>
+  add("normal", ({string, bool}) =>
+    <button disabled={bool("disabled", false)}>
+      {string("text", "hello")->React.string}
+    </button>
   )
 )
 

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -22,9 +22,10 @@
   ],
   "suffix": ".bs.js",
   "namespace": true,
-  "bs-dependencies": ["@rescript/react"],
+  "bs-dependencies": ["reason-react"],
   "warnings": {
     "number": "+A-4-9-20-102",
     "error": "+A"
-  }
+  },
+  "refmt": 3,
 }

--- a/example/Demo.res
+++ b/example/Demo.res
@@ -57,7 +57,7 @@ demo(({addDemo: _, addCategory}) => {
     addCategory("Headings", ({addDemo, addCategory: _}) => {
       addDemo("H1", ({string, int}) =>
         <h1
-          style={ReactDOM.Style.make(
+          style={ReactDOMRe.Style.make(
             ~fontSize={
               let size = int("Font size", {min: 0, max: 100, initial: 30, step: 1})
               j`$(size)px`
@@ -92,7 +92,7 @@ demo(({addDemo: _, addCategory}) => {
     addCategory(\"Headings\", ({addDemo, addCategory: _}) => {
       addDemo(\"H1\", ({string, int}) =>
         <h1
-          style={ReactDOM.Style.make(
+          style={ReactDOMRe.Style.make(
             ~fontSize={
               let size = int(\"Font size\", {min: 0, max: 100, initial: 30, step: 1})
               j`$(size)px`

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "bloodyowl <mlbli@me.com>",
   "license": "MIT",
   "dependencies": {
-    "@rescript/react": ">=0.10.0",
     "copy-webpack-plugin": "^8.1.0",
     "html-webpack-plugin": "^5.3.1",
+    "reason-react": ">=0.9.1",
     "webpack": "^5.35.1",
     "webpack-dev-server": "^3.11.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,20 @@
 {
-  "name": "reshowcase",
+  "name": "@ahrefs/reshowcase",
   "version": "5.1.0",
+  "description": "> A tool to create demos for your ReScript React components",
+  "main": "index.js",
+  "directories": {
+    "example": "example",
+    "lib": "lib"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ahrefs/reshowcase.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ahrefs/reshowcase/issues"
+  },
+  "homepage": "https://github.com/ahrefs/reshowcase#readme",
   "bin": {
     "reshowcase": "./commands/reshowcase"
   },

--- a/src/ReshowcaseUi.res
+++ b/src/ReshowcaseUi.res
@@ -135,7 +135,7 @@ let rightSidebarId = "rightSidebar"
 module Link = {
   @react.component
   let make = (~href, ~text: React.element, ~style=?, ~activeStyle=?) => {
-    let url = RescriptReactRouter.useUrl()
+    let url = ReasonReact.Router.useUrl()
     let path = String.concat("/", url.path)
     let isActive = (path ++ ("?" ++ url.search))->Js.String2.endsWith(href)
     <a
@@ -144,7 +144,7 @@ module Link = {
         switch (ReactEvent.Mouse.metaKey(event), ReactEvent.Mouse.ctrlKey(event)) {
         | (false, false) =>
           ReactEvent.Mouse.preventDefault(event)
-          RescriptReactRouter.push(href)
+          ReasonReact.Router.push(href)
         | _ => ()
         }}
       style=?{switch (style, activeStyle, isActive) {
@@ -207,7 +207,7 @@ module DemoListSidebar = {
         (),
       )
 
-      let input = ReactDOM.Style.make(
+      let input = ReactDOMRe.Style.make(
         ~padding=`${Gap.xs} ${Gap.md}`,
         ~width="100%",
         ~margin="0",
@@ -789,7 +789,7 @@ module App = {
 
   @react.component
   let make = (~demos: Demos.t) => {
-    let url = RescriptReactRouter.useUrl()
+    let url = ReasonReact.Router.useUrl()
     let urlSearchParams = url.search->URLSearchParams.make
     let route = switch (
       urlSearchParams->URLSearchParams.get("iframe"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,11 +44,6 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@rescript/react@>=0.10.0":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@rescript/react/-/react-0.10.3.tgz#a2a8bed6b017940ec26c2154764b350f50348889"
-  integrity sha512-Lf9rzrR3bQPKJjOK3PBRa/B3xrJ7CqQ1HYr9VHPVxJidarIJJFZBhj0Dg1uZURX+Wg/xiP0PHFxXmdj2bK8Vxw==
-
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
@@ -2634,6 +2629,11 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+reason-react@>=0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.9.1.tgz#30a887158200b659aa03e2d75ff4cc54dc462bb0"
+  integrity sha512-nlH0O2TDy9KzOLOW+vlEQk4ExHOeciyzFdoLcsmmiit6hx6H5+CVDrwJ+8aiaLT/kqK5xFOjy4PS7PftWz4plA==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
While we are on `reason-react`, we have to fork the tool to continue using it in our codebase.

cc @denis-ok