### PR TITLE
Handle webpack compilation errors

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -126,12 +126,26 @@ const compiler = webpack({
 });
 
 if (isBuild) {
-  console.log("Building reshowcase bundle...");
-  compiler.run((err, _result) => {
+  console.log("Building Reshowcase bundle...");
+  compiler.run((err, stats) => {
+    // https://webpack.js.org/api/node/#error-handling
     if (err) {
-      console.error(err);
+      console.error("Build failed. Webpack fatal errors:\n", err);
+      process.exit(1);
     } else {
-      console.log("Build finished.");
+      const info = stats.toJson();
+      if (stats.hasErrors && info.errors.length > 0) {
+        console.error(
+          "Build failed. Webpack complilation errors:\n",
+          info.errors
+        );
+        process.exit(1);
+      } else {
+        console.log(
+          stats.toString({ assets: true, chunks: true, colors: true })
+        );
+        console.log("Reshowcase build finished successfully.");
+      }
     }
   });
 } else {
@@ -155,16 +169,16 @@ if (isBuild) {
     ...(config.devServer || {}),
   });
 
-  ['SIGINT', 'SIGTERM'].forEach((signal) => {
+  ["SIGINT", "SIGTERM"].forEach((signal) => {
     process.on(signal, () => {
       if (server) {
         server.close(() => {
           process.exit();
-        })
+        });
       } else {
         process.exit();
       }
-    })
+    });
   });
 
   if (config.devServer && config.devServer.socket) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahrefs/reshowcase",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "> A tool to create demos for your ReScript React components",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Description

It turns out we don't display any Webpack compilation errors and don't stop a process with a non-zero exit code.
It leads to false-positive builds that fail in runtime.

Commit has been cherry-picked from here https://github.com/bloodyowl/reshowcase/pull/56