### PR TITLE
Support webpack `optimization`

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -94,10 +94,12 @@ const compiler = webpack({
   },
   output: {
     path: outputPath,
-    filename: "reshowcase[fullhash].js",
+    filename: "reshowcase-[name]-[fullhash].js",
     globalObject: "this",
     chunkLoadingGlobal: "reshowcase__d",
+    chunkFilename: '[id].[chunkhash].js'
   },
+  optimization: config.optimization,
   module: config.module,
   plugins: [
     ...(config.plugins ? config.plugins : []),


### PR DESCRIPTION
I was experimenting with split chunks in reshowcase and noticed that `optimization` field is not supported. 

I also had to change the naming rule, because without `[name]`, webpack will be producing artifacts with conflicting names.