### PR TITLE
Allow user to cusomize output in custom config

### DIFF
--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -110,7 +110,7 @@ const compiler = webpack({
   entry: {
     index: entryPath,
   },
-  output: {
+  output: config.output || {
     path: outputPath,
     filename: "reshowcase[fullhash].js",
     globalObject: "this",


### PR DESCRIPTION
In some case where I need to use a different output config such as have a custom `file name` and `publicPath` since we already allow user to add custom webpack config.