### PR TITLE
Only enable live reload in watch mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ watch: ## Watch for the filesystem and rebuild on every change
 .PHONY: test
 test: ## Run tests
 	$(DUNE) build @runtest
+	node --test commands/reshowcase.test.js
 
 .PHONY: start-example
 start-example: ## Runs the example in watch mode

--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -103,7 +103,23 @@ const customConfig = (() => {
 const watchPlugin = {
   name: "watchPlugin",
   setup: (build) => {
-    build.onEnd((_buildResult) => console.log("[reshowcase] Rebuild finished!"));
+    const htmlPath = path.join(build.initialOptions.outdir, "index.html");
+
+    build.onEnd(() => {
+      console.log("[reshowcase] Rebuild finished!");
+      if (!fs.existsSync(htmlPath)) {
+        return;
+      }
+      const html = fs.readFileSync(htmlPath, "utf8");
+      const liveReloadScript =
+        "<script>new EventSource('/esbuild').addEventListener('change', () => location.reload());</script>";
+      if (!html.includes(liveReloadScript)) {
+        fs.writeFileSync(
+          htmlPath,
+          html.replace("</head>", `  ${liveReloadScript}\n</head>`)
+        );
+      }
+    });
   },
 };
 

--- a/commands/reshowcase
+++ b/commands/reshowcase
@@ -103,28 +103,17 @@ const customConfig = (() => {
 const watchPlugin = {
   name: "watchPlugin",
   setup: (build) => {
-    const htmlPath = path.join(build.initialOptions.outdir, "index.html");
-
-    build.onEnd(() => {
-      console.log("[reshowcase] Rebuild finished!");
-      if (!fs.existsSync(htmlPath)) {
-        return;
-      }
-      const html = fs.readFileSync(htmlPath, "utf8");
-      const liveReloadScript =
-        "<script>new EventSource('/esbuild').addEventListener('change', () => location.reload());</script>";
-      if (!html.includes(liveReloadScript)) {
-        fs.writeFileSync(
-          htmlPath,
-          html.replace("</head>", `  ${liveReloadScript}\n</head>`)
-        );
-      }
-    });
+    build.onEnd((_buildResult) => console.log("[reshowcase] Rebuild finished!"));
   },
 };
 
 // entryPoint passed to htmlPlugin must be relative to the current working directory
 const entryPathRelativeToCwd = path.relative(process.cwd(), entryPath);
+const liveReloadScript =
+  "<script>new EventSource('/esbuild').addEventListener('change', () => location.reload());</script>";
+const uiTemplate = fs
+  .readFileSync(path.join(__dirname, "./ui-template.html"), "utf8")
+  .replace("<!-- live-reload -->", isBuild ? "" : liveReloadScript);
 
 const defaultConfig = {
   entryPoints: [entryPath],
@@ -166,7 +155,7 @@ const defaultConfig = {
         {
           filename: "index.html",
           entryPoints: [entryPathRelativeToCwd],
-          htmlTemplate: path.join(__dirname, "./ui-template.html"),
+          htmlTemplate: uiTemplate,
           scriptLoading: "module",
         },
         {

--- a/commands/reshowcase.test.js
+++ b/commands/reshowcase.test.js
@@ -1,0 +1,82 @@
+const assert = require("node:assert/strict");
+const { spawn, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const cliPath = path.join(__dirname, "reshowcase");
+
+const stopServer = (server) =>
+  new Promise((resolve) => {
+    if (server.exitCode !== null) {
+      resolve();
+      return;
+    }
+    server.once("exit", resolve);
+    server.kill("SIGTERM");
+  });
+
+const fetchHtml = async (url, server) => {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (server.exitCode !== null) {
+      throw new Error(`reshowcase exited with code ${server.exitCode}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return response.text();
+      }
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("reshowcase did not start within 5 seconds");
+};
+
+test("only enables live reload in watch mode", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "reshowcase-test-"));
+  const entryPath = path.join(tempDir, "entry.js");
+  const templatePath = path.join(tempDir, "template.html");
+  const outputPath = path.join(tempDir, "build");
+  fs.writeFileSync(
+    entryPath,
+    'document.getElementById("root").textContent = "Reshowcase";'
+  );
+  fs.writeFileSync(
+    templatePath,
+    '<!doctype html><html><head></head><body><div id="root"></div></body></html>'
+  );
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+  const build = spawnSync(
+    process.execPath,
+    [
+      cliPath,
+      "build",
+      `--entry=${entryPath}`,
+      `--template=${templatePath}`,
+      `--output=${outputPath}`,
+    ],
+    { encoding: "utf8" }
+  );
+  assert.equal(build.status, 0, build.stderr || build.stdout);
+  const builtHtml = fs.readFileSync(path.join(outputPath, "index.html"), "utf8");
+  assert.doesNotMatch(builtHtml, /EventSource|\/esbuild/);
+
+  const port = 20000 + (process.pid % 10000);
+  const server = spawn(
+    process.execPath,
+    [
+      cliPath,
+      "start",
+      `--entry=${entryPath}`,
+      `--template=${templatePath}`,
+      `--port=${port}`,
+    ],
+    { env: { ...process.env, TMPDIR: tempDir }, stdio: "ignore" }
+  );
+  t.after(() => stopServer(server));
+
+  const watchedHtml = await fetchHtml(`http://127.0.0.1:${port}/`, server);
+  assert.match(watchedHtml, /new EventSource\('\/esbuild'\)/);
+});

--- a/commands/ui-template.html
+++ b/commands/ui-template.html
@@ -33,9 +33,6 @@
         flex-grow: 1;
       }
     </style>
-    <script>
-      new EventSource('/esbuild').addEventListener('change', () => location.reload());
-    </script>
   </head>
 
   <body>

--- a/commands/ui-template.html
+++ b/commands/ui-template.html
@@ -33,6 +33,7 @@
         flex-grow: 1;
       }
     </style>
+    <!-- live-reload -->
   </head>
 
   <body>

--- a/example/Demo.re
+++ b/example/Demo.re
@@ -58,9 +58,9 @@ module Css = {
   ];
 };
 
-demo(({addDemo: _, addCategory}) =>
-  addCategory("Buttons", ({addDemo, addCategory: _}) => {
-    addDemo("Normal", ({string, bool, _}) => {
+demo(({ addDemo: _, addCategory }) =>
+  addCategory("Buttons", ({ addDemo, addCategory: _ }) => {
+    addDemo("Normal", ({ string, bool, _ }) => {
       let disabled = bool("Disabled", false);
       let color =
         string(
@@ -82,7 +82,7 @@ demo(({addDemo: _, addCategory}) =>
         {string("Text", "hello")->React.string}
       </button>;
     });
-    addDemo("Huge", ({string, bool, _}) => {
+    addDemo("Huge", ({ string, bool, _ }) => {
       let disabled = bool("Disabled", false);
       let color =
         string(
@@ -108,33 +108,41 @@ demo(({addDemo: _, addCategory}) =>
   })
 );
 
-demo(({addDemo: _, addCategory}) =>
-  addCategory("Typography", ({addDemo: _, addCategory}) => {
-    addCategory("Headings", ({addDemo, addCategory: _}) => {
-      addDemo("H1", ({string, int, _}) => {
+demo(({ addDemo: _, addCategory }) =>
+  addCategory("Typography", ({ addDemo: _, addCategory }) => {
+    addCategory("Headings", ({ addDemo, addCategory: _ }) => {
+      addDemo("H1", ({ string, int, _ }) => {
         let size =
-          int("Font size", {min: 0, max: 100, initial: 30, step: 1});
+          int(
+            "Font size",
+            {
+              min: 0,
+              max: 100,
+              initial: 30,
+              step: 1,
+            },
+          );
 
         <h1 className={Css.h1Size(size)}>
           {string("Text", "hello")->React.string}
         </h1>;
       });
-      addDemo("H2", ({string, _}) =>
+      addDemo("H2", ({ string, _ }) =>
         <h2> {string("Text", "hello")->React.string} </h2>
       );
     });
-    addCategory("Text", ({addDemo, addCategory: _}) => {
-      addDemo("Paragraph", ({string, _}) =>
+    addCategory("Text", ({ addDemo, addCategory: _ }) => {
+      addDemo("Paragraph", ({ string, _ }) =>
         <p> {string("Text", "hello")->React.string} </p>
       );
-      addDemo("Italic", ({string, _}) =>
+      addDemo("Italic", ({ string, _ }) =>
         <i> {string("Text", "hello")->React.string} </i>
       );
     });
   })
 );
 
-demo(({addDemo, addCategory: _}) =>
+demo(({ addDemo, addCategory: _ }) =>
   addDemo("Code example", _propsApi =>
     <code className=Css.code>
       {js|open Reshowcase.Entry;
@@ -169,8 +177,8 @@ demo(({addDemo: _, addCategory}) =>
   )
 );
 
-demo(({addDemo: _, addCategory}) =>
-  addCategory("Test search", ({addDemo, addCategory: _}) => {
+demo(({ addDemo: _, addCategory }) =>
+  addCategory("Test search", ({ addDemo, addCategory: _ }) => {
     addDemo("OneTwoThreeFour", _ => React.null);
     addDemo("OneTwoThreeFive", _ => React.null);
     addDemo("OneTwoFourSeven", _ => React.null);

--- a/reshowcase.opam
+++ b/reshowcase.opam
@@ -43,6 +43,6 @@ depexts: [
   ["@craftamap/esbuild-plugin-html"] {npm-version = "^0.6.1"}
 ]
 pin-depends: [
-  ["styled-ppx.dev" "git+https://github.com/davesnx/styled-ppx.git#aa0d3c533ea88418cd0fb82e13adbc59b6d4dfd3"]
-  ["server-reason-react.0.3.1" "git+https://github.com/ml-in-barcelona/server-reason-react#ce006ee5ad5562eee617a4c713b1efa317dc2aab"]
+  ["styled-ppx.dev" "git+https://github.com/davesnx/styled-ppx.git#dba7cbe0c1e875e55315728d46c16d7b461bcad7"]
+  ["server-reason-react.dev" "git+https://github.com/ml-in-barcelona/server-reason-react#555bc3402399eb51edf5b5b67c620bb19d1a5e57"]
 ]

--- a/reshowcase.opam.template
+++ b/reshowcase.opam.template
@@ -3,6 +3,6 @@ depexts: [
   ["@craftamap/esbuild-plugin-html"] {npm-version = "^0.6.1"}
 ]
 pin-depends: [
-  ["styled-ppx.dev" "git+https://github.com/davesnx/styled-ppx.git#aa0d3c533ea88418cd0fb82e13adbc59b6d4dfd3"]
-  ["server-reason-react.0.3.1" "git+https://github.com/ml-in-barcelona/server-reason-react#ce006ee5ad5562eee617a4c713b1efa317dc2aab"]
+  ["styled-ppx.dev" "git+https://github.com/davesnx/styled-ppx.git#dba7cbe0c1e875e55315728d46c16d7b461bcad7"]
+  ["server-reason-react.dev" "git+https://github.com/ml-in-barcelona/server-reason-react#555bc3402399eb51edf5b5b67c620bb19d1a5e57"]
 ]

--- a/src/ReshowcaseUi.re
+++ b/src/ReshowcaseUi.re
@@ -611,7 +611,7 @@ module DemoUnitSidebar = {
          ->React.array}
         {ints
          ->Map.String.toArray
-         ->Array.map(((propName, ({Configs.min, max, _}, value))) =>
+         ->Array.map(((propName, ({ Configs.min, max, _ }, value))) =>
              <PropBox key=propName propName>
                <input
                  type_="number"
@@ -631,7 +631,7 @@ module DemoUnitSidebar = {
          ->React.array}
         {floats
          ->Map.String.toArray
-         ->Array.map(((propName, ({Configs.min, max, _}, value))) =>
+         ->Array.map(((propName, ({ Configs.min, max, _ }, value))) =>
              <PropBox key=propName propName>
                <input
                  type_="number"
@@ -915,7 +915,8 @@ module DemoUnitFrame = {
         border: none;
         height: $(height);
         width: $(width);
-      |}];
+      |}
+      ];
     };
   };
 

--- a/tests/HighlightTermsTest.re
+++ b/tests/HighlightTermsTest.re
@@ -4,7 +4,14 @@ external process: 'a = "process";
 [@mel.module] external util: 'a = "util";
 
 let inspect = (value): string =>
-  util##inspect(value, {"compact": false, "depth": 20, "colors": true});
+  util##inspect(
+    value,
+    {
+      "compact": false,
+      "depth": 20,
+      "colors": true,
+    },
+  );
 
 let exitWithError = (): unit => process##exit(1);
 


### PR DESCRIPTION
## Summary

- inject the `/esbuild` EventSource only in watch mode so deployed builds stop issuing 404 requests
- add an end-to-end CLI regression test covering build and watch modes
- update styled-ppx and server-reason-react pins for QuickJS 0.6-compatible APIs
- apply the repository formatter output required by `make format-check`

## Testing

- `opam-check-npm-deps`
- `make format-check`
- `make build`
- `make test`